### PR TITLE
Keyset Final Expiry

### DIFF
--- a/02.md
+++ b/02.md
@@ -70,6 +70,7 @@ The mint and the wallets of its users can derive a keyset ID from the keyset of 
 1 - sort public keys by their amount in ascending order
 2 - concatenate all public keys to one byte array
 3 - add the unit string to the byte array (e.g. "unit:sat")
+4 - If a final expiration is specified, convert it into a radix-10 string and add it (e.g "final_expiry:1896187313")
 4 - HASH_SHA256 the concatenated byte array
 5 - prefix it with a keyset ID version byte
 ```
@@ -81,6 +82,7 @@ def derive_keyset_id(keys: Dict[int, PublicKey]) -> str:
     sorted_keys = dict(sorted(keys.items()))
     keyset_id_bytes = b"".join([p.serialize() for p in sorted_keys.values()])
     keyset_id_bytes += b"unit:sat"
+    keyset_id_bytes += b"final_expiry:"+str(1896187313).encode("utf-8")
     return "01" + hashlib.sha256(keyset_id_bytes).hexdigest()
 ```
 
@@ -102,6 +104,17 @@ def derive_keyset_id(keys: Dict[int, PublicKey]) -> str:
     pubkeys_concat = b"".join([p.serialize() for p in sorted_keys.values()])
     return "00" + hashlib.sha256(pubkeys_concat).hexdigest()[:14]
 ```
+
+### Keyset Final Expiry
+
+A unix epoch number for a future point in time that represents the final expiry of the keyset. After the keyset's final expiry, the Mint is no longer obliged to fulfill promises signed with the keys from that keyset.
+
+This effectively implies that the Mint can irrevocably remove all of the nullifiers (`Y` values/spent ecash) associated with the expired keyset.
+
+The final expiry can be `null` if the keyset has no final-expiry.
+
+> [!IMPORTANT]
+> Good final expirations should be years into the future.
 
 ## Example: Get mint keysets
 
@@ -129,6 +142,7 @@ Response `GetKeysetsResponse` of `Bob`:
       "unit": <str>,
       "active": <bool>,
       "input_fee_ppk": <int|null>,
+      "final_expiry": <int|null>
     },
     ...
   ]
@@ -146,19 +160,22 @@ Here, `id` is the keyset ID, `unit` is the unit string (e.g. "sat") of the keyse
       "id": "01c9c20fb8b348b389e296227c6cc7a63f77354b7388c720dbba6218f720f9b785",
       "unit": "sat",
       "active": true,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     },
     {
       "id": "0188432103b12cec6361587d92bdfb798079c58b1c828c561b4daec6f4d465a810",
       "unit": "sat",
       "active": false,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     },
     {
       "id": "01d0257bde6ff4cd55e49318a824bbe67e2f9faa248ff108203b5fe46581b14ffc",
       "unit": "usd",
       "active": true,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     }
   ]
 }

--- a/02.md
+++ b/02.md
@@ -113,9 +113,6 @@ This effectively implies that the Mint can irrevocably remove all of the nullifi
 
 The final expiry can be `null` if the keyset has no final-expiry.
 
-> [!IMPORTANT]
-> Good final expirations should be years into the future.
-
 ## Example: Get mint keysets
 
 A wallet can ask the mint for a list of all keysets via the `GET /v1/keysets` endpoint.


### PR DESCRIPTION
Allow a Mint to get rid of very old keysets and nullifiers (spent ecash) associated with them:
keysets now specify a "final expiry" after which the Mint is no longer obligated to serve ecash signed with keys belonging to that keyset.