### PR TITLE
Rewrite keyset ID section for clarity (`id` vs `s_id`)

### DIFF
--- a/02.md
+++ b/02.md
@@ -14,13 +14,19 @@ A mint can have multiple keysets at the same time. For example, it could have on
 
 ### Keyset ID
 
-A keyset `id` is an identifier for a specific keyset. It can be derived by anyone who knows the set of public keys of a mint. Wallets **MAY** compute the keyset `id` for a given keyset by themselves to confirm that the mint is supplying the correct keyset ID (see below).
+A keyset `id` is its identifier, derived from its content. It is 33 bytes, consisting of one version byte and a 32 byte hash (see below).
 
-The keyset `id` is in each `Proof` so it can be used by wallets to identify which mint and keyset it was generated from. The keyset field `id` is also present in the `BlindedMessages` sent to the mint and `BlindSignatures` returned from the mint (see [NUT-00][00]).
+The keyset short ID (`s_id`) is an abbreviated version of the `id` and consists of its first eight bytes (`id_bytes[:8]` or `id_hex[:16]`). The `s_id` is used only in Proofs that are embedded in a Token, in order to keep the Token size small. All other places that reference the Keyset ID use the full `id`.
 
-To save space, a `Token`, as defined in [NUT-00][00], **SHOULD** contain an abbreviated version of the keyset `id` in the `Proof`, (the `s_id`). The length of the `s_id` **MUST** be eight bytes (i.e., the version byte and the first seven bytes of the hash: `id_bytes[:8]` or `id_hex[:16]`). A wallet **MUST** resolve the abbreviated keyset `id` to the full `id`. If the abbreviated `s_id` is ambiguous (i.e., multiple keyset `id`s are resolvable), the wallet **MUST** error. The full keyset `id` is only needed when the wallet interacts with the mint.
+Wallets **SHOULD** derive the keyset `id` on their own when fetching the keysets from the mint, to confirm the mint is supplying the correct keyset `id`.
 
-A Wallet **SHOULD** save the full-length keyset `id` with proofs in its database.
+Wallets **MUST** use the full keyset `id` in their internal DB structures instead of the `s_id`.
+
+Wallets **MUST** use the short keyset `s_id` when sending ecash, i.e. when constructing the Proofs in a Token.
+
+When receiving a Token, a wallet **MUST** resolve the abbreviated `s_id` to the full `id`. If the abbreviated `s_id` is ambiguous (i.e., multiple keyset `id`s are resolvable), the wallet **MUST** error.
+
+Mints **MUST** use the full `id`, both in their API and internally in their DB structures.
 
 ### Active keysets
 


### PR DESCRIPTION
This PR rewrites the "Keyset ID" section to better distinguish when should which ID be used.